### PR TITLE
Introduce utils to generate custom URDFs on-the-fly

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Steps to generate API docs
+
+ 1. Create a Python 3.9 virtual env using `conda create -n "pdmd2" python=3.9 ipython` and activate it
+ 1. Install pydoc-markdown using `pip install git+https://github.com/hello-binit/pydoc-markdown.git@develop`
+ 1. Run `pydoc-markdown -m stretch_urdf.urdf_utils -I $(pwd) --render-toc > docs/urdf_utils.md` in the "~/repos/stretch_urdf" folder
+ 1. By default, each method is made heading 4 with `####`. My preference is to make it heading 2 (delete 2 `##` each) to make it easier to discern where one method's docs ends and the next starts.

--- a/docs/urdf_utils.md
+++ b/docs/urdf_utils.md
@@ -1,0 +1,167 @@
+# Table of Contents
+
+* [stretch\_urdf.urdf\_utils](#stretch_urdf.urdf_utils)
+  * [get\_latest\_urdf](#stretch_urdf.urdf_utils.get_latest_urdf)
+  * [clip\_joint\_limits](#stretch_urdf.urdf_utils.clip_joint_limits)
+  * [make\_joints\_rigid](#stretch_urdf.urdf_utils.make_joints_rigid)
+  * [merge\_arm](#stretch_urdf.urdf_utils.merge_arm)
+  * [add\_virtual\_rotary\_joint](#stretch_urdf.urdf_utils.add_virtual_rotary_joint)
+  * [generate\_urdf\_from\_robot](#stretch_urdf.urdf_utils.generate_urdf_from_robot)
+  * [generate\_ik\_urdfs](#stretch_urdf.urdf_utils.generate_ik_urdfs)
+
+<a id="stretch_urdf.urdf_utils"></a>
+
+# stretch\_urdf.urdf\_utils
+
+<a id="stretch_urdf.urdf_utils.get_latest_urdf"></a>
+
+## get\_latest\_urdf
+
+```python
+def get_latest_urdf()
+```
+
+Fetches the latest calibrated URDF from the calibration directory.
+
+**Returns**
+
+* `str`: Absolute filepath to the latest calibrated URDF.
+
+<a id="stretch_urdf.urdf_utils.clip_joint_limits"></a>
+
+## clip\_joint\_limits
+
+```python
+def clip_joint_limits(robot, use_original_limits=True)
+```
+
+Enables more conservative joint limits to be set than in the
+original URDF.
+
+If these limits are outside the originally permitted range,
+the original range is used. Joint limits. Where these limits
+have a value of None, the original limit is used.
+
+**Arguments**
+
+* **robot** (`urdf_parser_py.urdf.Robot`): a manipulable URDF representation
+* **use_original_limits** (`bool`): don't impose any additional limits
+
+**Returns**
+
+* `urdf_parser_py.urdf.Robot`: modified URDF where joint limits are clipped
+
+<a id="stretch_urdf.urdf_utils.make_joints_rigid"></a>
+
+## make\_joints\_rigid
+
+```python
+def make_joints_rigid(robot, ignore_joints=None)
+```
+
+Change any joint that should be immobile for end effector IK
+into a fixed joint.
+
+**Arguments**
+
+* **robot** (`urdf_parser_py.urdf.Robot`): a manipulable URDF representation
+* **ignore_joints** (`list(str) or None`): which joints to keep as-is
+
+**Returns**
+
+* `urdf_parser_py.urdf.Robot`: modified URDF where joints are "fixed"
+
+<a id="stretch_urdf.urdf_utils.merge_arm"></a>
+
+## merge\_arm
+
+```python
+def merge_arm(robot)
+```
+
+Replace telescoping arm with a single prismatic joint,
+which makes end-effector IK computation easier.
+
+**Arguments**
+
+* **robot** (`urdf_parser_py.urdf.Robot`): a manipulable URDF representation
+
+**Returns**
+
+* `urdf_parser_py.urdf.Robot`: modified URDF with single arm joint
+
+<a id="stretch_urdf.urdf_utils.add_virtual_rotary_joint"></a>
+
+## add\_virtual\_rotary\_joint
+
+```python
+def add_virtual_rotary_joint(robot)
+```
+
+Add virtual rotary joint for mobile base.
+
+**Arguments**
+
+* **robot** (`urdf_parser_py.urdf.Robot`): a manipulable URDF representation
+
+**Returns**
+
+* `urdf_parser_py.urdf.Robot`: modified URDF with mobile base rotation joint
+
+<a id="stretch_urdf.urdf_utils.generate_urdf_from_robot"></a>
+
+## generate\_urdf\_from\_robot
+
+```python
+def generate_urdf_from_robot(robot, app_name, description=None)
+```
+
+Renders a `robot` URDF object out to a file in the /tmp
+folder. The file will be unique to your application given
+the `app_name` isn't the same as other applications.
+
+This enables you to safety generate URDFs on-the-fly
+to be used by your app. E.g. `generate_ik_urdfs()` uses
+this method to generate "calibrated" inverse kinematics
+URDFs, so each robot's unique backlash and skew parameters
+are baked into the IK calculations.
+
+**Arguments**
+
+* **robot** (`urdf_parser_py.urdf.Robot`): the URDF representation to render out to a file
+* **app_name** (`str`): the name of your application
+* **description** (`str or None`): further description of the URDF
+
+**Returns**
+
+* `str`: filepath of the generated URDF
+
+<a id="stretch_urdf.urdf_utils.generate_ik_urdfs"></a>
+
+## generate\_ik\_urdfs
+
+```python
+def generate_ik_urdfs(app_name, rigid_wrist_urdf=True)
+```
+
+Generates URDFs for IK packages. The latest calibrated
+URDF is used as a starting point, then these modifications
+are applied:
+  1. Clip joint limits
+  2. Make non-IK joints rigid
+  3. Merge arm joints
+  4. Add virtual rotary base joint
+  5. (optionally) Make wrist joints rigid
+
+**Arguments**
+
+* **app_name** (`str`): the name of your application
+* **rigid_wrist_urdf** (`bool or None`): whether to also generate a IK URDF with a fixed dex wrist
+
+**Returns**
+
+* `list(str)`: one or two filepaths, depending on `rigid_wrist_urdf`,
+to the generated URDFs. The first element will be the
+full IK version, and the second will be the rigid
+wrist version.
+

--- a/stretch_urdf/urdf_utils.py
+++ b/stretch_urdf/urdf_utils.py
@@ -1,0 +1,308 @@
+import pathlib
+import numpy as np
+import stretch_body.hello_utils as hu
+from urdf_parser_py import urdf as ud
+from typing import Dict, Optional, Tuple
+
+
+def get_latest_urdf():
+    """
+    Fetches the latest calibrated URDF from the calibration directory.
+
+    Returns
+    -------
+    str
+        Absolute filepath to the latest calibrated URDF.
+    """
+    try:
+        fleet_dir = hu.get_fleet_directory()
+    except:
+        raise FileNotFoundError("Stretch data directory doesn't exist") from None
+    calibration_dir = pathlib.Path(fleet_dir) / "exported_urdf"
+    if not calibration_dir.is_dir():
+        raise FileNotFoundError("URDF calibration directory doesn't exist")
+    urdf_path = calibration_dir / "stretch.urdf"
+    if not urdf_path.is_file():
+        raise FileNotFoundError("URDF doesn't exist")
+    urdf_filename = str(urdf_path.absolute())
+    return urdf_filename
+
+
+def clip_joint_limits(robot, use_original_limits=True):
+    """
+    Enables more conservative joint limits to be set than in the
+    original URDF.
+
+    If these limits are outside the originally permitted range,
+    the original range is used. Joint limits. Where these limits
+    have a value of None, the original limit is used.
+
+    Parameters
+    ----------
+    robot : urdf_parser_py.urdf.Robot
+        a manipulable URDF representation
+    use_original_limits : bool
+        don't impose any additional limits
+
+    Returns
+    -------
+    urdf_parser_py.urdf.Robot
+        modified URDF where joint limits are clipped
+    """
+    ik_joint_limits: Dict[str, Tuple[Optional[float], Optional[float]]] = {}
+    if use_original_limits:
+        ik_joint_limits = {
+            "joint_mobile_base_translation": (None, None),
+            "joint_mobile_base_rotation": (None, None),
+            "joint_lift": (None, None),
+            "joint_arm_l0": (None, None),
+            "joint_wrist_yaw": (None, None),
+            "joint_wrist_pitch": (-0.8 * (np.pi / 2.0), None), # Beware of gimbal lock if joint_wrist_pitch is too close to -90 deg
+            "joint_wrist_roll": (None, None),
+        }
+    else:
+        ik_joint_limits = {
+            "joint_mobile_base_translation": (-0.25, 0.25),
+            "joint_mobile_base_rotation": (-(np.pi / 2.0), np.pi / 2.0),
+            "joint_lift": (0.01, 1.09),
+            "joint_arm_l0": (0.01, 0.48),
+            "joint_wrist_yaw": (-(np.pi / 4.0), np.pi),
+            "joint_wrist_pitch": (-0.9 * (np.pi / 2.0), np.pi / 20.0),
+            "joint_wrist_roll": (-(np.pi / 2.0), np.pi / 2.0),
+        }
+
+    for j in ik_joint_limits:
+        joint = robot.joint_map.get(j, None)
+        if joint is not None:
+            original_upper = joint.limit.upper
+            requested_upper = ik_joint_limits[j][1]
+            if requested_upper is not None:
+                new_upper = min(requested_upper, original_upper)
+                robot.joint_map[j].limit.upper = new_upper
+
+            original_lower = joint.limit.lower
+            requested_lower = ik_joint_limits[j][0]
+            if requested_lower is not None:
+                new_lower = max(requested_lower, original_lower)
+                robot.joint_map[j].limit.lower = new_lower
+
+
+def make_joints_rigid(robot, ignore_joints=None):
+    """
+    Change any joint that should be immobile for end effector IK
+    into a fixed joint.
+
+    Parameters
+    ----------
+    robot : urdf_parser_py.urdf.Robot
+        a manipulable URDF representation
+    ignore_joints : list(str) or None
+        which joints to keep as-is
+
+    Returns
+    -------
+    urdf_parser_py.urdf.Robot
+        modified URDF where joints are "fixed"
+    """
+    if ignore_joints is None:
+        ignore_joints = []
+
+    for j in robot.joint_map.keys():
+        if j not in ignore_joints:
+            joint = robot.joint_map[j]
+            joint.type = "fixed"
+
+
+def merge_arm(robot):
+    """
+    Replace telescoping arm with a single prismatic joint,
+    which makes end-effector IK computation easier.
+
+    Parameters
+    ----------
+    robot : urdf_parser_py.urdf.Robot
+        a manipulable URDF representation
+
+    Returns
+    -------
+    urdf_parser_py.urdf.Robot
+        modified URDF with single arm joint
+    """
+    all_arm_joints = [
+        "joint_arm_l4",
+        "joint_arm_l3",
+        "joint_arm_l2",
+        "joint_arm_l1",
+        "joint_arm_l0",
+    ]
+    prismatic_arm_joints = all_arm_joints[1:]
+    removed_arm_joints = all_arm_joints[1:-1]
+    near_proximal_arm_joint = robot.joint_map[all_arm_joints[1]]
+    distal_arm_joint = robot.joint_map[all_arm_joints[-1]]
+
+    # Calculate aggregate joint characteristics
+    xyz_total = np.array([0.0, 0.0, 0.0])
+    limit_upper_total = 0.0
+    for j in prismatic_arm_joints:
+        joint = robot.joint_map[j]
+        xyz_total = xyz_total + joint.origin.xyz
+        limit_upper_total = limit_upper_total + joint.limit.upper
+
+    # Directly connect the proximal and distal parts of the arm
+    distal_arm_joint.parent = near_proximal_arm_joint.parent
+
+    # Make the distal prismatic joint act like the full arm
+    distal_arm_joint.origin.xyz = xyz_total
+    distal_arm_joint.limit.upper = limit_upper_total
+
+    # Mark the eliminated joints as "fixed"
+    for j in removed_arm_joints:
+        joint = robot.joint_map[j]
+        joint.type = "fixed"
+
+
+def add_virtual_rotary_joint(robot):
+    """
+    Add virtual rotary joint for mobile base.
+
+    Parameters
+    ----------
+    robot : urdf_parser_py.urdf.Robot
+        a manipulable URDF representation
+
+    Returns
+    -------
+    urdf_parser_py.urdf.Robot
+        modified URDF with mobile base rotation joint
+    """
+    link_virtual_base_rotary = ud.Link(
+        name="virtual_base", visual=None, inertial=None, collision=None, origin=None
+    )
+    origin_rotary = ud.Pose(xyz=[0, 0, 0], rpy=[0, 0, 0])
+    limit_rotary = ud.JointLimit(effort=10, velocity=1, lower=-np.pi, upper=np.pi)
+    joint_mobile_base_rotation = ud.Joint(
+        name="joint_mobile_base_rotation",
+        parent="virtual_base",
+        child="base_link",
+        joint_type="revolute",
+        axis=[0, 0, 1],
+        origin=origin_rotary,
+        limit=limit_rotary,
+        dynamics=None,
+        safety_controller=None,
+        calibration=None,
+        mimic=None,
+    )
+    robot.add_link(link_virtual_base_rotary)
+    robot.add_joint(joint_mobile_base_rotation)
+
+
+def generate_urdf_from_robot(robot, app_name, description=None):
+    """
+    Renders a `robot` URDF object out to a file in the /tmp
+    folder. The file will be unique to your application given
+    the `app_name` isn't the same as other applications.
+
+    This enables you to safety generate URDFs on-the-fly
+    to be used by your app. E.g. `generate_ik_urdfs()` uses
+    this method to generate "calibrated" inverse kinematics
+    URDFs, so each robot's unique backlash and skew parameters
+    are baked into the IK calculations.
+
+    Parameters
+    ----------
+    robot : urdf_parser_py.urdf.Robot
+        the URDF representation to render out to a file
+    app_name : str
+        the name of your application
+    description : str or None
+        further description of the URDF
+
+    Returns
+    -------
+    str
+        filepath of the generated URDF
+    """
+    if description is None:
+        description = "custom"
+
+    def save_urdf(robot, file_name):
+        urdf_string = robot.to_xml_string()
+        with open(file_name, "w") as fid:
+            fid.write(urdf_string)
+
+    filename = f'/tmp/{app_name}_{description}.urdf'
+    save_urdf(robot, filename)
+
+    return filename
+
+
+def generate_ik_urdfs(app_name, rigid_wrist_urdf=True):
+    """
+    Generates URDFs for IK packages. The latest calibrated
+    URDF is used as a starting point, then these modifications
+    are applied:
+      1. Clip joint limits
+      2. Make non-IK joints rigid
+      3. Merge arm joints
+      4. Add virtual rotary base joint
+      5. (optionally) Make wrist joints rigid
+
+    Parameters
+    ----------
+    app_name : str
+        the name of your application
+    rigid_wrist_urdf : bool or None
+        whether to also generate a IK URDF with a fixed dex wrist
+
+    Returns
+    -------
+    list(str)
+        one or two filepaths, depending on `rigid_wrist_urdf`,
+        to the generated URDFs. The first element will be the
+        full IK version, and the second will be the rigid
+        wrist version.
+    """
+
+    robot = ud.Robot.from_xml_file(get_latest_urdf())
+    clip_joint_limits(robot)
+
+    ignore_joints = [
+        "joint_lift",
+        "joint_arm_l0",
+        "joint_arm_l1",
+        "joint_arm_l2",
+        "joint_arm_l3",
+        "joint_wrist_yaw",
+        "joint_wrist_pitch",
+        "joint_wrist_roll",
+    ]
+    make_joints_rigid(robot, ignore_joints)
+
+    merge_arm(robot)
+
+    add_virtual_rotary_joint(robot)
+
+    ret = []
+    fpath = generate_urdf_from_robot(robot, app_name, 'base_rotation_ik')
+    ret.append(fpath)
+
+    if rigid_wrist_urdf:
+        ignore_joints = [
+            "joint_mobile_base_translation",
+            "joint_mobile_base_rotation",
+            "joint_lift",
+            "joint_arm_l0",
+        ]
+        make_joints_rigid(robot, ignore_joints)
+
+        fpath = generate_urdf_from_robot(robot, app_name, 'base_rotation_ik_with_fixed_wrist')
+        ret.append(fpath)
+
+    return ret
+
+
+if __name__ == "__main__":
+    print(generate_ik_urdfs('stretch_web_teleop'))
+    with open('/tmp/stretch_web_teleop_base_rotation_ik.urdf', 'r') as fid:
+        print(fid.read())


### PR DESCRIPTION
Caching URDFs is a bad idea because a robot's "calibrated" URDF is unique to it, and likely won't work as well or at all on another Stretch robot. Even within a single robot, calibration parameters (e.g. backlash, offset, etc.) change over time, and it's common for users to use Stretch Calibration to recalibrate their robot. By caching the IK URDFs, apps aren't keeping up with the latest calibration. This can also make debugging complicated because developers can't trust if their application is using the latest calibration.

This PR introduces a utils module for generating custom URDFs on-the-fly. Docs for the module in the `docs/urdf_utils.md` file.